### PR TITLE
Added top-level module that calls path modules

### DIFF
--- a/paths2openscad.py
+++ b/paths2openscad.py
@@ -41,6 +41,7 @@ import cubicsuperpath
 import cspsubdiv
 import bezmisc
 import re
+import string
 
 DEFAULT_WIDTH = 100
 DEFAULT_HEIGHT = 100
@@ -973,10 +974,9 @@ fudge = 0.1;
 
             # Come up with a name for the module based on the file name.
             name = os.path.splitext( os.path.basename( self.options.fname ) )[0]
-            import string
-            all = string.maketrans('', '')
             # Remove all punctuation except underscore.
-            name.translate(all, string.punctuation.replace('_', ''))
+            name = re.sub('[' + string.punctuation.replace('_', '') + ']', '', name)
+
             self.f.write('\nmodule %s(h)\n{\n' % name)
 
             # Now output the list of modules to call


### PR DESCRIPTION
I have added top-level module that calls all the sub-modules and is named based on the file name.  This makes it easier to import the entire set of paths into another OpenSCAD model.  I find that I usually want to import into another model and it was tedious to keep editing the OpenSCAD file generated by paths2openscad when something was updated in Inkscape.  To include in another OpenSCAD file, the following assumes that a filename of "cool_design5.scad" is used:

> use &lt;cool_design5&gt;;
> 
> cool_design5(5);
