### PR TITLE
Reverting back paths2openscad.py

### DIFF
--- a/paths2openscad.py
+++ b/paths2openscad.py
@@ -1004,4 +1004,4 @@ fudge = 0.1;
 
 if __name__ == '__main__':
     e = OpenSCAD()
-    e.effect()
+    e.affect()


### PR DESCRIPTION
e.effect() changed back to e.affect() on @su-v request